### PR TITLE
Add option to specify Perl6 module include path

### DIFF
--- a/flycheck-perl6.el
+++ b/flycheck-perl6.el
@@ -40,9 +40,19 @@
   :group 'flycheck
   :link '(url-link :tag "Github" "https://github.com/hinrik/flycheck-perl6"))
 
+(flycheck-def-option-var flycheck-perl6-include-path nil perl6
+  "A list of include directories for Perl6.
+
+The value of this variable is a list of strings, where each
+string is a directory to add to the include path of Perl6.
+Relative paths are relative to the file being checked."
+  :type '(repeat (directory :tag "Include directory"))
+  :safe #'flycheck-string-list-p)
+
 (flycheck-define-checker perl6
   "A Perl 6 syntax checker."
-  :command ("perl6" "-c" source)
+  :command ("perl6" "-c"
+            (option-list "-I" flycheck-perl6-include-path) source)
   :error-patterns
   ((error (or (and line-start (message) "\nat " (file-name) ":" line line-end)
               (and "compiling " (file-name) "\n" (message (minimal-match (1+ anything))) " at line " line))))


### PR DESCRIPTION
Adapt Flycheck's own `flycheck-perl-include-path` for Perl 6,
customizable in project `.dir-locals.el`, e.g.

``` emacs-lisp
((perl6-mode . ((flycheck-perl6-include-path . ("lib" "../lib")))))
```
