### PR TITLE
`module not found' gets the right prompt instead of `suspicious state'

### DIFF
--- a/flycheck-perl6.el
+++ b/flycheck-perl6.el
@@ -45,7 +45,9 @@
   :command ("perl6" "-c" source)
   :error-patterns
   ((error (or (and line-start (message) "\nat " (file-name) ":" line line-end)
-              (and "compiling " (file-name) "\n" (message (minimal-match (1+ anything))) " at line " line))))
+              (and "compiling " (file-name) "\n" (message (minimal-match (1+ anything))) " at line " line)
+              ; "Module not found" message
+              (and "===SORRY!===\n" (message (minimal-match (1+ anything))) " at line " line))))
   :modes perl6-mode)
 
 (add-to-list 'flycheck-checkers 'perl6)


### PR DESCRIPTION
Currently, Flycheck displays the following message when a module `use`d in the code is not found.

```
Suspicious state from syntax checker perl6: Flycheck checker perl6 returned non-zero exit code 1, but its output contained no errors: ===SORRY!===
Could not find (ModuleName) at line 3 in:
```

The patch correctly displays this as an `error`.